### PR TITLE
CFW退出时强制终止`clash-linux`进程

### DIFF
--- a/io.github.Fndroid.clash_for_windows.desktop
+++ b/io.github.Fndroid.clash_for_windows.desktop
@@ -5,6 +5,6 @@ Exec=sh -c "cfw.sh %U ; pkill clash-linux"
 Icon=io.github.Fndroid.clash_for_windows
 Encoding=UTF-8
 Terminal=false
-StartupNotify=true
+StartupNotify=false
 Type=Application
 Categories=Network;

--- a/io.github.Fndroid.clash_for_windows.desktop
+++ b/io.github.Fndroid.clash_for_windows.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Clash for Windows
 Comment=A Windows/macOS/Linux GUI based on Clash and Electron.
-Exec=cfw.sh %U
+Exec=sh -c "cfw.sh %U ; pkill clash-linux"
 Icon=io.github.Fndroid.clash_for_windows
 Encoding=UTF-8
 Terminal=false


### PR DESCRIPTION
绕过上游bug